### PR TITLE
fix: the bom module was missing in the root pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,7 @@
     <module>grpc-google-identity-accesscontextmanager-v1</module>
     <module>proto-google-identity-accesscontextmanager-v1</module>
     <module>proto-google-identity-accesscontextmanager-type</module>
+    <module>google-identity-accesscontextmanager-bom</module>
   </modules>
 
   <reporting>


### PR DESCRIPTION
The bom module was missing in the root pom. It caused build failure in another issue in google-cloud-java repository: https://github.com/googleapis/google-cloud-java/pull/7991#issuecomment-1179254748

Other repositories declare the bom module correctly. Example: https://github.com/googleapis/java-accessapproval/blob/main/pom.xml#L116